### PR TITLE
Update IPO serializer to accept IPO ID for document creation

### DIFF
--- a/Database/Rahul/ipo_backend/ipo/serializers.py
+++ b/Database/Rahul/ipo_backend/ipo/serializers.py
@@ -8,15 +8,15 @@ class CompanySerializer(serializers.ModelSerializer):
 
 
 class IPOSerializer(serializers.ModelSerializer):
-    company = CompanySerializer(read_only=True)
-
+    company = serializers.PrimaryKeyRelatedField(queryset=Company.objects.all())
+    company_detail = CompanySerializer(source='company', read_only=True)
     class Meta:
         model = IPO
         fields = '__all__'
 
 
 class DocumentSerializer(serializers.ModelSerializer):
-    ipo = IPOSerializer(read_only=True)
+    ipo = serializers.PrimaryKeyRelatedField(queryset=IPO.objects.all())
 
     class Meta:
         model = Document


### PR DESCRIPTION
### Summary
- Added models for Company, IPO, Document, User, Application
- Implemented serializers for all models
- Enabled creation of IPOs and linked Documents
- Cleaned .gitignore to exclude .pyc and __pycache__

### Status
- [x] Model and API tested locally using Postman
- [x] Document creation linked to IPO (foreign key)

### Next Steps
- Add user authentication
- Implement Application API
- Pagination and search filters
